### PR TITLE
Correct config name for using Jekyll server in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,10 +92,10 @@ This guard has these configurations.
 
 ### Using Jekyll Server
 
-To use Jekyll's built-in server, simply set `:server => true` in your rack options
+To use Jekyll's built-in server, simply set `:serve => true` in your rack options
 
 ```ruby
-guard "jekyll-plus", :server => true do
+guard "jekyll-plus", :serve => true do
   watch /.*/
   ignore /^_site/
 end


### PR DESCRIPTION
in Using Jekyll Server section, `:server` option should be `:serve` so it matches the value in config table and also starts Jekyll server up.
