### PR TITLE
Check Jekyll exclude before copying modified files to _site dir.

### DIFF
--- a/lib/guard/jekyll-plus.rb
+++ b/lib/guard/jekyll-plus.rb
@@ -46,7 +46,7 @@ module Guard
       @msg_prefix = @options[:msg_prefix]
  
       # Convert array of extensions into a regex for matching file extensions eg, /\.md$|\.markdown$|\.html$/i
-      #
+      # 
       extensions  = @options[:extensions].concat(default_extensions).flatten.uniq
       @extensions = Regexp.new extensions.map { |e| (e << '$').gsub('\.', '\\.') }.join('|'), true
 
@@ -85,7 +85,6 @@ module Guard
     def run_on_modifications(paths)
       matched = jekyll_matches paths
       unmatched = non_jekyll_matches paths
-
       if matched.size > 0
         build(matched, "Files changed: ", "  ~ ".yellow)
       elsif unmatched.size > 0
@@ -147,10 +146,14 @@ module Guard
           UI.info "#{@msg_prefix} #{message.green}" unless @config[:silent]
           puts '| ' #spacing
           files.each do |file|
-            path = destination_path file
-            FileUtils.mkdir_p File.dirname(path)
-            FileUtils.cp file, path
-            puts '|' + "  → ".green + path
+            if(!check_jekyll_exclude(file))
+              path = destination_path file
+              FileUtils.mkdir_p File.dirname(path)
+              FileUtils.cp file, path
+              puts '|' + "  → ".green + path
+            else
+              puts '|' + "  ~ ".yellow + "'#{file}' detected in Jekyll exclude, not copying".red
+            end
           end
           puts '| ' #spacing
 
@@ -227,6 +230,10 @@ module Guard
         config = options
       end
       ::Jekyll.configuration(config)
+    end
+
+    def check_jekyll_exclude(path)
+      return @config['exclude'].any? {|f| File.fnmatch?(path, f)}
     end
 
     def rack_config(root)

--- a/test/Testfile
+++ b/test/Testfile
@@ -1,0 +1,1 @@
+Don't copy me.

--- a/test/_config.yml
+++ b/test/_config.yml
@@ -1,2 +1,3 @@
 source: ./
 port: 4000
+exclude: ['Testfile', 'Guardfile', 'Gemfile', 'Gemfile.lock']


### PR DESCRIPTION
Before a file is copied into the site directory, first verify that it is not part of the Jekyll exclude configuration setting. This is useful for ensuring that only Jekyll files are copied into the built site folder (ie., the Guardfile should never be copied into the site folder).

Related to issue #23 
