### PR TITLE
Handle Thin not being installed

### DIFF
--- a/lib/guard/jekyll_plus/server.rb
+++ b/lib/guard/jekyll_plus/server.rb
@@ -86,7 +86,7 @@ module Guard
 
         @config.info "Using: #{s.server} as server"
 
-        # If thin is not install, this will throw a LoadError
+        # If Thin is not installed, this will throw a LoadError
         begin
           thin = s.server == Rack::Handler::Thin
         rescue LoadError

--- a/lib/guard/jekyll_plus/server.rb
+++ b/lib/guard/jekyll_plus/server.rb
@@ -86,7 +86,13 @@ module Guard
 
         @config.info "Using: #{s.server} as server"
 
-        thin = s.server == Rack::Handler::Thin
+        # If thin is not install, this will throw a LoadError
+        begin
+          thin = s.server == Rack::Handler::Thin
+        rescue LoadError
+          thin = nil
+        end
+
         Thin::Logging.silent = @config.rack_environment.nil? if thin
 
         @pid = Process.fork { s.start }


### PR DESCRIPTION
If thin is not installed jekyll-plus would fail to catch a LoadError
exception. This fixes that issue by wrapping the call to
Rack::Handler:Thin in a being-rescue block
